### PR TITLE
fix: ignore ERROR events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,8 +14,6 @@ module.exports = (hermione, pluginOpts) => {
     hermione.on(hermione.events.SUITE_FAIL, (fail) => failCollector.addFail(fail));
     hermione.on(hermione.events.TEST_FAIL, (fail) => failCollector.addFail(fail));
     hermione.on(hermione.events.RETRY, (retry) => failCollector.addFail(retry));
-    // `data` already contains `error` in its property `err`
-    hermione.on(hermione.events.ERROR, (error, data) => failCollector.addFail(data));
 
     hermione.on(hermione.events.RUNNER_END, () => failCollector.generateReport());
 };

--- a/test/lib/index.js
+++ b/test/lib/index.js
@@ -57,12 +57,6 @@ describe('hermione-faildump', () => {
         assert.calledWith(FailCollector.prototype.addFail, {some: 'data'});
     });
 
-    it('should handle an error emmitted by event `ERROR`', () => {
-        hermione.emit(hermione.events.ERROR, null, {some: 'data'});
-
-        assert.calledWith(FailCollector.prototype.addFail, {some: 'data'});
-    });
-
     it('should generate a faildump report on event `RUNNER_END`', () => {
         hermione.emit(hermione.events.RUNNER_END);
 


### PR DESCRIPTION
`ERROR` event doesn't contain test data. It's a generic error